### PR TITLE
Delete assessment

### DIFF
--- a/API/src/microservices/Assessment-Service/index.js
+++ b/API/src/microservices/Assessment-Service/index.js
@@ -44,3 +44,32 @@ exports.retrieve = () => {
     }
   });
 };
+
+exports.delete = (assessmentId) => {
+  return new Promise(async (resolve, reject) => { //eslint-disable-line
+    try {
+      const date = new Date();
+      const shortDate = `${date.getFullYear()}-${date.getMonth()+1}-${date.getDate()} ${date.getHours()}:${date.getMinutes()}:${date.getSeconds()}`;
+
+      //from https://stackoverflow.com/questions/41914802/how-do-i-properly-update-models-with-bookshelf-js
+      await new Assessments({'id':assessmentId}).fetch()
+      .then(function (model) {
+        if (model) {
+          var params = { 'deleted_at': shortDate }
+           model.save(params, {
+            method: 'update',
+            patch: true
+          });
+        } 
+      })
+      .then(()=>{resolve()})
+      .catch(function (err) {
+          console.log("error in deleting assessment", err);
+          resolve();
+      });
+
+    } catch (err) {
+      reject();
+    }
+  });
+};

--- a/API/src/microservices/Database/index.js
+++ b/API/src/microservices/Database/index.js
@@ -24,7 +24,8 @@ bookshelf.plugin(`bookshelf-virtuals-plugin`);
 bookshelf.plugin(require(`bookshelf-soft-delete`));
 
 const Assessments = bookshelf.Model.extend({
-  tableName: `assessments`
+  tableName: `assessments`,
+  soft: ['deleted_at']
 });
 
 const Users = bookshelf.Model.extend({

--- a/API/src/routes/Assessment/index.js
+++ b/API/src/routes/Assessment/index.js
@@ -50,4 +50,28 @@ module.exports = server => {
       }
     }
   );
+
+  
+  server.post(
+    `${ BASE_URL }/delete`,
+    async (req, res, next) => {
+      try {
+
+        let  {assessmentId}  = req.params;
+        assessmentId = assessmentId.assessmentId;
+
+        await AssessmentService.delete(assessmentId);
+
+        ResponseHandler(
+          res,
+          'Assessment deleted successfully',
+          null,
+          next
+        );
+      } catch (err) {
+        console.log(err)
+        next(err);
+      }
+    }
+  );
 };

--- a/OCAT/client/resources/js/components/Assessments/list.js
+++ b/OCAT/client/resources/js/components/Assessments/list.js
@@ -11,29 +11,7 @@ export function AssessmentList(){
 
     useEffect(function fetch() {
         (async function() {
-            const resData = await AssessmentService.retrieveAll();
-            const columnedData = []
-            resData.data.forEach(assessment => {
-                
-                let dateOfBirth = Date.parse(assessment.cat_date_of_birth);
-                dateOfBirth = new Date (dateOfBirth);
-                dateOfBirth = dateOfBirth.toLocaleDateString("en-US");
-                
-                let createdAt = Date.parse(assessment.created_at);
-                createdAt = new Date (createdAt);
-                createdAt = createdAt.toLocaleString("en-US");
-                
-                columnedData.push(
-                    {
-                        column1: assessment.cat_name,
-                        column2: dateOfBirth,
-                        column3: assessment.instrument,
-                        column4: assessment.risk_level,
-                        column5: assessment.score+'',
-                        column6: createdAt,
-                    })
-            });
-            setColumnsArray(columnedData);
+            updateAssessmentState();
         })();
     },[]);
         
@@ -82,6 +60,12 @@ export function AssessmentList(){
                 {
                 Header: 'Created at',
                 accessor: 'column6',
+                sortType: 'basic', 
+                Filter: columnFilter
+                },
+                {
+                Header: 'Remove',
+                accessor: 'column7',
                 sortType: 'basic', 
                 Filter: columnFilter
                 },
@@ -203,5 +187,47 @@ export function AssessmentList(){
                 </div>
             </div>
         );
+    }
+
+    async function  deleteAssessment(id){   
+        await AssessmentService.deleteAssessment(id).then(()=>{
+            updateAssessmentState();
+        });
+
+    }
+
+    async function updateAssessmentState(){
+        const resData = await AssessmentService.retrieveAll();
+            const columnedData = []
+            resData.data.forEach(assessment => {
+
+                let dateOfBirth = Date.parse(assessment.cat_date_of_birth);
+                dateOfBirth = new Date (dateOfBirth);
+                dateOfBirth = dateOfBirth.toLocaleDateString("en-US");
+
+                let createdAt = Date.parse(assessment.created_at);
+                createdAt = new Date (createdAt);
+                createdAt = createdAt.toLocaleString("en-US");
+
+                let btnDelete = 
+                <button 
+                    type="button"
+                    className="btn btn-danger"
+                    id ={assessment.id}
+                    onClick={deleteAssessment.bind(this, assessment.id)}
+                >Delete</button>
+
+                columnedData.push(
+                    {
+                        column1: assessment.cat_name,
+                        column2: dateOfBirth,
+                        column3: assessment.instrument,
+                        column4: assessment.risk_level,
+                        column5: assessment.score+'',
+                        column6: createdAt,
+                        column7: btnDelete,
+                    })
+            });
+            setColumnsArray(columnedData);
     }
 }

--- a/OCAT/client/resources/js/components/shared/services/assessment.service.js
+++ b/OCAT/client/resources/js/components/shared/services/assessment.service.js
@@ -28,4 +28,16 @@ export class AssessmentService {
             throw new Error(`${err.response.statusText} - ${err.response.data.message}`);
         }
     }
+
+    static async deleteAssessment(id) {
+        try {
+            await axios.post('http://localhost:4567/api/assessment/delete',{
+                assessmentId: id
+              });
+            
+        }
+        catch (err) {
+            throw new Error(`${err.response.statusText} - ${err.response.data.message}`);
+        }
+    }
 }

--- a/OCAT/server/libs/AssessmentService/index.js
+++ b/OCAT/server/libs/AssessmentService/index.js
@@ -42,6 +42,33 @@ exports.submit = ( assessment ) => {
           },
           json: true
       };
+
+      request(options, (error, response) => {
+        if(error == null){
+          resolve(response);
+        }
+        if(error != null){
+          reject(error);
+        }
+      });
+    });
+  };
+
+  exports.delete = ( assessmentId) => {
+    return new Promise((resolve, reject) => {
+  
+      //supply the correct uri and method here
+      const options = {
+          uri: `http://${ config.api.url}/assessment/delete/`,
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json'
+          },
+          body: {
+            assessmentId: assessmentId
+          },
+          json: true
+      };
   
       //this function sends a request to the API
       // finish the logic to handle the response when returned from the API

--- a/OCAT/server/routes/AssessmentAPI/index.js
+++ b/OCAT/server/routes/AssessmentAPI/index.js
@@ -14,16 +14,20 @@ router.post(`/submit`, (req, res) => {
 
 router.get(`/retrieve`, (req, res) => {
     //Only supervisors can view assessment list
-    if(req.session && req.session.isSupervisor)
-    AssessmentService.retrieve().then((response) => {
-         res.send(response.body.data)        
-      });
+    if(req.session && req.session.isSupervisor){
+        AssessmentService.retrieve().then((response) => {
+            res.send(response.body.data)        
+        });
+    }
 });
 
 router.post(`/delete`, (req, res) => {
-    AssessmentService.delete(req.body).then((response) => {
-        res.send(response.body)        
-     });;
+    //Only supervisors can delete an assessment
+    if(req.session && req.session.isSupervisor){
+        AssessmentService.delete(req.body).then((response) => {
+          res.send(response.body)        
+        });;
+    }
 });
 
 exports.router = router;

--- a/OCAT/server/routes/AssessmentAPI/index.js
+++ b/OCAT/server/routes/AssessmentAPI/index.js
@@ -20,5 +20,11 @@ router.get(`/retrieve`, (req, res) => {
       });
 });
 
+router.post(`/delete`, (req, res) => {
+    AssessmentService.delete(req.body).then((response) => {
+        res.send(response.body)        
+     });;
+});
+
 exports.router = router;
 exports.path = `/api/assessment`; 


### PR DESCRIPTION
Enables supervisor to delete assessments from the assessment table.
Uses bookshelf's (library) soft delete.
The assessment list displayed in the react table gets updated automatically with no reloading of the page.

![image](https://user-images.githubusercontent.com/54749949/113611822-09f1ed80-961d-11eb-89fa-978dfd9b9d1a.png)
